### PR TITLE
Auto Select Hawaii Dept of Health

### DIFF
--- a/android/app/BUCK
+++ b/android/app/BUCK
@@ -35,12 +35,12 @@ android_library(
 
 android_build_config(
     name = "build_config",
-    package = "org.pathcheck.covidsafepaths",
+    package = "org.alohasafe.story",
 )
 
 android_resource(
     name = "res",
-    package = "org.pathcheck.covidsafepaths",
+    package = "org.alohasafe.story",
     res = "src/main/res",
 )
 

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -10,7 +10,7 @@
 # Add any project specific keep options here:
 
 # react-native-config, prevents obfuscating of .env flags
--keep class org.pathcheck.covidsafepaths.BuildConfig { *; }
+-keep class org.alohasafe.story.BuildConfig { *; }
 
 -keep class androidx.core.app.CoreComponentFactory { *; }
 

--- a/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/gps/DetoxTest.java
+++ b/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/gps/DetoxTest.java
@@ -1,4 +1,4 @@
-package org.pathcheck.covidsafepaths.gps;
+package org.alohasafe.story.gps;
 
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.filters.LargeTest;
@@ -9,7 +9,7 @@ import com.wix.detox.Detox;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.pathcheck.covidsafepaths.MainActivity;
+import org.alohasafe.story.MainActivity;
 
 @RunWith(AndroidJUnit4.class)
 @LargeTest

--- a/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/gps/storage/GeohashTests.kt
+++ b/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/gps/storage/GeohashTests.kt
@@ -1,4 +1,4 @@
-package org.pathcheck.covidsafepaths.gps.storage
+package org.alohasafe.story.gps.storage
 
 //
 //  GeohashTests.kt

--- a/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/gps/storage/LocationTest.kt
+++ b/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/gps/storage/LocationTest.kt
@@ -1,4 +1,4 @@
-package org.pathcheck.covidsafepaths.gps.storage
+package org.alohasafe.story.gps.storage
 
 import covidsafepaths.gps.storage.Location
 import org.junit.Assert.*

--- a/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/gps/storage/RealmSecureStorageTest.kt
+++ b/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/gps/storage/RealmSecureStorageTest.kt
@@ -1,4 +1,4 @@
-package org.pathcheck.covidsafepaths.gps.storage
+package org.alohasafe.story.gps.storage
 
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.WritableMap

--- a/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/gps/storage/TestPromise.kt
+++ b/android/app/src/androidTest/java/org/pathcheck/covidsafepaths/gps/storage/TestPromise.kt
@@ -1,4 +1,4 @@
-package org.pathcheck.covidsafepaths.gps.storage
+package org.alohasafe.story.gps.storage
 
 import com.facebook.react.bridge.Promise
 import com.facebook.react.bridge.WritableMap

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="org.pathcheck.covidsafepaths">
+  package="org.alohasafe.story">
 
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
     <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />

--- a/android/app/src/main/java/covidsafepaths/gps/MainApplication.java
+++ b/android/app/src/main/java/covidsafepaths/gps/MainApplication.java
@@ -10,7 +10,7 @@ import com.marianhello.bgloc.BackgroundGeolocationFacade;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
 import com.facebook.soloader.SoLoader;
-import org.pathcheck.covidsafepaths.BuildConfig;
+import org.alohasafe.story.BuildConfig;
 import io.realm.Realm;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;

--- a/android/app/src/main/java/org.pathcheck.covidsafepaths/MainActivity.java
+++ b/android/app/src/main/java/org.pathcheck.covidsafepaths/MainActivity.java
@@ -1,4 +1,4 @@
-package org.pathcheck.covidsafepaths;
+package org.alohasafe.story;
 
 import android.app.Activity;
 import android.os.Bundle;

--- a/android/app/src/main/java/org.pathcheck.covidsafepaths/SplashActivity.java
+++ b/android/app/src/main/java/org.pathcheck.covidsafepaths/SplashActivity.java
@@ -1,4 +1,4 @@
-package org.pathcheck.covidsafepaths;
+package org.alohasafe.story;
 
 import android.content.Intent;
 import android.os.Bundle;

--- a/android/fastlane/Appfile
+++ b/android/fastlane/Appfile
@@ -1,2 +1,2 @@
 json_key_file("./app/json_key.json") # Path to the json secret file - Follow https://docs.fastlane.tools/actions/supply/#setup to get one
-package_name("org.pathcheck.covidsafepaths") # e.g. com.krausefx.app
+package_name("org.alohasafe.story") # e.g. com.krausefx.app

--- a/app/Entry.js
+++ b/app/Entry.js
@@ -44,8 +44,8 @@ import isOnboardingCompleteSelector from './store/selectors/isOnboardingComplete
 import getHealthcareAuthorities from './store/actions/healthcareAuthorities/getHealthcareAuthoritiesAction';
 import isHdohSelectedSelector from './store/selectors/isHdohSelectedSelector';
 import isAuthorityListLoadedSelector from './store/selectors/isAuthorityListLoadedSelector';
-import healthcareAuthorityOptionsSelector from './store/selectors/healthcareAuthorityOptionsSelector'
-import autoSelectHdohAction from './store/actions/healthcareAuthorities/autoSelectHdohAction'
+import healthcareAuthorityOptionsSelector from './store/selectors/healthcareAuthorityOptionsSelector';
+import autoSelectHdohAction from './store/actions/healthcareAuthorities/autoSelectHdohAction';
 ////// ALOHA SAFE STORY EDITS //////
 
 import { isPlatformAndroid } from './Util';
@@ -253,8 +253,8 @@ export const Entry = () => {
   const onboardingComplete = useSelector(isOnboardingCompleteSelector);
 
   ////// ALOHA SAFE STORY EDITS //////
-  const authorityListLoaded = useSelector(isAuthorityListLoadedSelector)
-  const healthcareAuthorities = useSelector(healthcareAuthorityOptionsSelector)
+  const authorityListLoaded = useSelector(isAuthorityListLoadedSelector);
+  const healthcareAuthorities = useSelector(healthcareAuthorityOptionsSelector);
   const hdohSelected = useSelector(isHdohSelectedSelector);
 
   const dispatch = useDispatch();
@@ -265,7 +265,7 @@ export const Entry = () => {
   }
   // Sets to Hawaii Dept. of Health
   if (!hdohSelected) {
-    dispatch(autoSelectHdohAction({healthcareAuthorities}));
+    dispatch(autoSelectHdohAction({ healthcareAuthorities }));
   }
   ////// ALOHA SAFE STORY EDITS //////
   return (

--- a/app/Entry.js
+++ b/app/Entry.js
@@ -10,7 +10,7 @@ import {
   TransitionPresets,
   createStackNavigator,
 } from '@react-navigation/stack';
-import { useSelector } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 
 import SettingsScreen from './views/Settings';
 import AboutScreen from './views/About';
@@ -39,6 +39,15 @@ import { Screens, Stacks } from './navigation';
 
 // import ExposureHistoryContext from './ExposureHistoryContext';
 import isOnboardingCompleteSelector from './store/selectors/isOnboardingCompleteSelector';
+
+////// ALOHA SAFE STORY EDITS //////
+import getHealthcareAuthorities from './store/actions/healthcareAuthorities/getHealthcareAuthoritiesAction';
+import isHdohSelectedSelector from './store/selectors/isHdohSelectedSelector';
+import isAuthorityListLoadedSelector from './store/selectors/isAuthorityListLoadedSelector';
+import healthcareAuthorityOptionsSelector from './store/selectors/healthcareAuthorityOptionsSelector'
+import autoSelectHdohAction from './store/actions/healthcareAuthorities/autoSelectHdohAction'
+////// ALOHA SAFE STORY EDITS //////
+
 import { isPlatformAndroid } from './Util';
 import { useTracingStrategyContext } from './TracingStrategyContext';
 
@@ -243,6 +252,22 @@ const PartnersStack = () => (
 export const Entry = () => {
   const onboardingComplete = useSelector(isOnboardingCompleteSelector);
 
+  ////// ALOHA SAFE STORY EDITS //////
+  const authorityListLoaded = useSelector(isAuthorityListLoadedSelector)
+  const healthcareAuthorities = useSelector(healthcareAuthorityOptionsSelector)
+  const hdohSelected = useSelector(isHdohSelectedSelector);
+
+  const dispatch = useDispatch();
+  // Fetches and sets HAs from yaml on launch if it is not stored.
+  // WARNING: No special error handling in case of failure in this section. Handled through the action/reducer
+  if (!authorityListLoaded) {
+    dispatch(getHealthcareAuthorities());
+  }
+  // Sets to Hawaii Dept. of Health
+  if (!hdohSelected) {
+    dispatch(autoSelectHdohAction({healthcareAuthorities}));
+  }
+  ////// ALOHA SAFE STORY EDITS //////
   return (
     <NavigationContainer>
       <Stack.Navigator screenOptions={SCREEN_OPTIONS}>

--- a/app/store/actions/healthcareAuthorities/autoSelectHdohAction.ts
+++ b/app/store/actions/healthcareAuthorities/autoSelectHdohAction.ts
@@ -6,8 +6,7 @@ type Payload = {
   // No custom URLs like toggleSelect action
 };
 
-const AUTO_SELECT_HDOH =
-  'AUTO_SELECT_HDOH';
+const AUTO_SELECT_HDOH = 'AUTO_SELECT_HDOH';
 
 const autoSelectHdohAction = createAction(
   AUTO_SELECT_HDOH,

--- a/app/store/actions/healthcareAuthorities/autoSelectHdohAction.ts
+++ b/app/store/actions/healthcareAuthorities/autoSelectHdohAction.ts
@@ -1,0 +1,19 @@
+import { createAction } from '@reduxjs/toolkit';
+import type { HealthcareAuthority } from '../../types';
+
+type Payload = {
+  healthcareAuthorities: HealthcareAuthority[];
+  // No custom URLs like toggleSelect action
+};
+
+const AUTO_SELECT_HDOH =
+  'AUTO_SELECT_HDOH';
+
+const autoSelectHdohAction = createAction(
+  AUTO_SELECT_HDOH,
+  ({ healthcareAuthorities }: Payload) => ({
+    payload: { healthcareAuthorities },
+  }),
+);
+
+export default autoSelectHdohAction;

--- a/app/store/reducers/healthcareAuthoritiesReducer.ts
+++ b/app/store/reducers/healthcareAuthoritiesReducer.ts
@@ -10,6 +10,10 @@ import {
 import toggleSelectedHealthcareAuthorityAction from '../actions/healthcareAuthorities/toggleSelectedHealthcareAuthorityAction';
 import toggleAutoSubscriptionBannerAction from '../actions/healthcareAuthorities/toggleAutoSubscriptionBannerAction';
 
+////// ALOHA SAFE STORY EDITS //////
+import autoSelectHdohAction from '../actions/healthcareAuthorities/autoSelectHdohAction';
+////// ALOHA SAFE STORY EDITS //////
+
 type HealthCareReducerState = {
   // Because we control this list to be super small and have type safety, we use the full models
   // rather than a normalized map / id list paradigm.
@@ -77,6 +81,16 @@ const healthcareAuthoritiesReducer = createReducer(initialState, (builder) =>
       state.request.status = ApiStatus.FAILURE;
       state.request.errorMessage = error.message;
     })
+    ////// ALOHA SAFE STORY EDITS //////
+    .addCase(
+      autoSelectHdohAction,
+      (state, { payload: { healthcareAuthorities } }) => {
+        // Sets selected authorities array to the fetched authorities array. 
+        // CAUTION: Does not check against current state array. Assuming on one Hawaii Dept. of Health object.
+        state.selectedAuthorities = healthcareAuthorities
+      },
+    )
+    ////// ALOHA SAFE STORY EDITS //////
     .addCase(
       toggleSelectedHealthcareAuthorityAction,
       (

--- a/app/store/reducers/healthcareAuthoritiesReducer.ts
+++ b/app/store/reducers/healthcareAuthoritiesReducer.ts
@@ -85,9 +85,9 @@ const healthcareAuthoritiesReducer = createReducer(initialState, (builder) =>
     .addCase(
       autoSelectHdohAction,
       (state, { payload: { healthcareAuthorities } }) => {
-        // Sets selected authorities array to the fetched authorities array. 
+        // Sets selected authorities array to the fetched authorities array.
         // CAUTION: Does not check against current state array. Assuming on one Hawaii Dept. of Health object.
-        state.selectedAuthorities = healthcareAuthorities
+        state.selectedAuthorities = healthcareAuthorities;
       },
     )
     ////// ALOHA SAFE STORY EDITS //////

--- a/app/store/selectors/isHdohSelectedSelector.ts
+++ b/app/store/selectors/isHdohSelectedSelector.ts
@@ -1,6 +1,8 @@
 import { RootState } from '../types';
 // Checks state if there is a selected health authority and if it's Hawaii Dept. of Health.
 const isHdohSelectedSelector = (state: RootState): boolean =>
-  state.healthcareAuthorities.selectedAuthorities.length > 0 && state.healthcareAuthorities.selectedAuthorities[0].name.indexOf('Hawaii') !== -1;
+  state.healthcareAuthorities.selectedAuthorities.length > 0 &&
+  state.healthcareAuthorities.selectedAuthorities[0].name.indexOf('Hawaii') !==
+    -1;
 
 export default isHdohSelectedSelector;

--- a/app/store/selectors/isHdohSelectedSelector.ts
+++ b/app/store/selectors/isHdohSelectedSelector.ts
@@ -1,0 +1,6 @@
+import { RootState } from '../types';
+// Checks state if there is a selected health authority and if it's Hawaii Dept. of Health.
+const isHdohSelectedSelector = (state: RootState): boolean =>
+  state.healthcareAuthorities.selectedAuthorities.length > 0 && state.healthcareAuthorities.selectedAuthorities[0].name.indexOf('Hawaii') !== -1;
+
+export default isHdohSelectedSelector;


### PR DESCRIPTION
#### Description:

Auto selects HDoH as the healthcare authority (HA) on entry if it is not selected. If there are not health authorities in state, it will fetch it from the API. It will also run if a user tries to uncheck HDoH.

- Uses `isHdohSelectedSelector` to check Redux store and fires `autoSelectHdohAction` to select HDoH if it is not selected.

-  `isHdohSelectedSelector` checks if "Hawaii" exists in the HA object. It will not work if "Hawaii" is missing.

- Changed `org.pathcheck.covidsafepaths` to `org.alohasafe.story` in all files.

#### How to test:

Clear data from the app, run through the onboarding process, and check if HDoH is selected.